### PR TITLE
add last item margin reset to container include

### DIFF
--- a/flx-grid.scss
+++ b/flx-grid.scss
@@ -31,6 +31,10 @@ $flxst-direction: 	row 		!default; //directions "row", "row-reverse", "column" a
 	flex-direction: $flxst-direction;
 	direction: ltr;
 
+	> :last-child {
+		margin-#{$flxlstd}: 0;
+	}
+
 	 @if $flxmy == $flxcntmy {
 		$flxcntmy: $flxcntmx;
 	}


### PR DESCRIPTION
Why not reset the right margin of the last item with the `> :last-child` selector in the container include?
